### PR TITLE
[Fixes]: Typo is qpdf part 

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -147,7 +147,7 @@ parts:
 
   qpdf:
     source: https://github.com/qpdf/qpdf
-    source: git
+    source-type: git
     source-tag: 'v11.8.0'
     source-depth: 1
 # ext:updatesnap


### PR DESCRIPTION
Here is typo a fix in qpdf part which was accidental change in my last PR